### PR TITLE
Fallback to builtin json-library when `object_hook` is passed to .loads

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+## Version 2.0.1
+
+Unreleased
+
+- Fallback to the builtin `json`-library when an `object_hook` is passed to `.loads`
+  since `orjson` cannot handle this. This ensures full compatibility and correct
+  serialization with `get_flashed_messages(with_categories=True)`.
+
 ## Version 2.0.0
 
 Released 2024-01-14

--- a/src/flask_orjson/provider.py
+++ b/src/flask_orjson/provider.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import typing as t
 from decimal import Decimal
 
@@ -68,9 +69,13 @@ class OrjsonProvider(JSONProvider):
         return orjson.dumps(obj, option=option, default=default).decode()
 
     def loads(self, s: str | bytes, **kwargs: t.Any) -> t.Any:
-        """Deserialize data as JSON.
+        """Deserialize data as JSON. If an ``object_hook``-kwarg is passed,
+        which ``orjson`` cannot handle, fallback to the builtin ``json``.
 
         :param s: Text or UTF-8 bytes.
         :param kwargs: All keyword arguments are silently ignored.
         """
+        if "object_hook" in kwargs:
+            return json.loads(s, **kwargs)
+
         return orjson.loads(s)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from flask_orjson import OrjsonProvider
 @pytest.fixture
 def app() -> Flask:
     app = Flask(__name__)
+    app.config["SECRET_KEY"] = "secret_key"
     app.json = OrjsonProvider(app)
     return app
 

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -8,7 +8,10 @@ from decimal import Decimal
 
 import orjson
 import pytest
+from flask import flash
 from flask import Flask
+from flask import get_flashed_messages
+from flask import redirect
 from flask import request
 from flask.testing import FlaskClient
 
@@ -84,3 +87,19 @@ def test_method_default(app: Flask) -> None:
 
     rv = app.json.dumps({"a": Decimal(1)}, default=default)
     assert rv == """{"a":"default"}"""
+
+
+def test_request_post_with_session_flash_msg_with_categories(
+    app: Flask,
+    client: FlaskClient,
+) -> None:
+    @app.route("/", methods=["GET", "POST"])
+    def test() -> t.Any:
+        if request.method == "POST":
+            flash("flash")
+            return redirect("/")
+
+        return get_flashed_messages(with_categories=True)
+
+    rv = client.post("/", follow_redirects=True)
+    assert rv.json == [["message", "flash"]]


### PR DESCRIPTION
We discussed this briefly on the discord already with @CheeseCake87 - using `flask-orjson`, as is, breaks `get_flashed_messages(with_categories=True)` - instead of becoming: `[["message", "flash"]]` it ends up being `[{" t": ["message", "flash"]}]` which cannot be unpacked the usual way in a template. This has to do with the "Tagged JSON" system which is used in this case.

Happy to hear your thoughts on this - this is imo the easiest way to make this (almost) a drop-in replacement for now without breaking `flash`.

